### PR TITLE
Addition of "ON UPDATE CASCASE"  to the database file

### DIFF
--- a/app/userservices.py
+++ b/app/userservices.py
@@ -116,8 +116,18 @@ class UserService:
             results = cur.execute(sql)
             mysql.connection.commit()
 
-            #Create default list
+            #update the list username field 
             sql = ("UPDATE list " 
+                    "SET username = '" +new_username + "'"
+                    " WHERE username = '"+query_username + "'"
+            )
+            
+            print(f'SQL Output {sql}', file=sys.stderr)
+            results = cur.execute(sql)
+            mysql.connection.commit()
+
+            #update the reminder username field 
+            sql = ("UPDATE reminders " 
                     "SET username = '" +new_username + "'"
                     " WHERE username = '"+query_username + "'"
             )

--- a/db/init.sql
+++ b/db/init.sql
@@ -25,7 +25,7 @@ CREATE TABLE list (
 	listname VARCHAR(20),
     listdesc VARCHAR(100),
     username VARCHAR(20),
-    FOREIGN KEY(Username) REFERENCES users(username)
+    FOREIGN KEY(Username) REFERENCES users(username) ON UPDATE CASCADE
 );
 
 CREATE TABLE reminders(
@@ -37,8 +37,8 @@ CREATE TABLE reminders(
     flaged BOOL,
 	username VARCHAR(20),
 	listid INT,
-	FOREIGN KEY(Username) REFERENCES users(username),
-	FOREIGN KEY(listid) REFERENCES list(listid)
+	FOREIGN KEY(Username) REFERENCES users(username) ON UPDATE CASCADE,
+	FOREIGN KEY(listid) REFERENCES list(listid) ON UPDATE CASCADE
 );
 
 INSERT INTO users(username, password, profile) 


### PR DESCRIPTION
This update pertains to updating a user profile. If the user wants to change their username and they already have reminders or lists made, then the user will get a foreign key integrity error. This update changes the database scheme to cascade when there is an update so it applies to all tables with the common username. 